### PR TITLE
Fix compilation on Xcode 13

### DIFF
--- a/LineReader/LineReader/LineReader.swift
+++ b/LineReader/LineReader/LineReader.swift
@@ -17,7 +17,7 @@ public class LineReader {
     public var nextLine: String? {
         var line:UnsafeMutablePointer<CChar>? = nil
         var linecap:Int = 0
-        defer { free(line) }
+        defer { if (line != nil) { free(line!) } }
         return getline(&line, &linecap, file) > 0 ? String(cString: line!) : nil
     }
     


### PR DESCRIPTION
# Description

On Xcode 13, an error is reported:
```
LineReader.swift:20:22: value of optional type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') must be unwrapped to a value of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>')
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Compilation succeeds on Xcode 13

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
